### PR TITLE
Automatically detect active provider

### DIFF
--- a/lib/vagrant-ignition/action/merge_ignition.rb
+++ b/lib/vagrant-ignition/action/merge_ignition.rb
@@ -52,7 +52,7 @@ def merge_ignition(ignition_path, hostname, ip, env, provider)
     config[:networkd][:units] ||= []
     if provider == "virtualbox"
       config[:networkd][:units] += [virtualbox_ip_entry(ip)]
-    elsif provider == "vmware"
+    elsif provider =~ /^vmware/
       config[:networkd][:units] += [vmware_ip_entry(ip)]
     else
       env[:machine].ui.info "WARNING: Invalid config.ignition.provider; failed to configure networking"

--- a/lib/vagrant-ignition/action/setup_ignition.rb
+++ b/lib/vagrant-ignition/action/setup_ignition.rb
@@ -23,7 +23,7 @@ module VagrantPlugins
 
           hostname = env[:machine].config.ignition.hostname
           ip = env[:machine].config.ignition.ip
-          provider = env[:machine].config.ignition.provider
+          provider = env[:machine].provider_name.to_s
 
           merge_ignition(ignition_path, hostname, ip, env, provider)
           if provider == "virtualbox"
@@ -31,7 +31,7 @@ module VagrantPlugins
 
             env[:machine].ui.info "Configuring Ignition Config Drive"
             env[:machine].provider.driver.execute("storageattach", "#{env[:machine].id}", "--storagectl", "IDE Controller", "--device", "0", "--port", "1", "--type", "hdd", "--medium", "#{File.join(drive_root, (drive_name + ".vmdk"))}")
-          elsif provider == "vmware"
+          elsif provider =~ /^vmware/
             data = ""
             if !ignition_path.nil?
               data = File.read(ignition_path + ".merged")


### PR DESCRIPTION
When `vagrant` is called the currently used provider is stored in `env[:machine].provider_name` as Symbol. With this change the provider is taken from there reducing configuration and space for mistakes.

Signed-off-by: Mathias Kaufmann <me@stei.gr>